### PR TITLE
Add benchmarks for Rust qp-trie

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,18 +1,11 @@
 [package]
-
 name = "benchmark"
 version = "0.0.1"
 authors = ["Michael Sproul <micsproul@gmail.com>"]
 
 [lib]
-
 name = "benchmark"
 
-[dependencies.radix_trie]
-
-git = "https://github.com/michaelsproul/rust_radix_trie.git"
-branch = "new-stuff"
-
-[dependencies.sequence_trie]
-
-git = "https://github.com/michaelsproul/rust_sequence_trie.git"
+[dependencies]
+radix_trie = "0.1"
+qp-trie = "0.6"

--- a/rust/src/benchmark.rs
+++ b/rust/src/benchmark.rs
@@ -4,6 +4,8 @@ use std::io::Read;
 use std_test::Bencher;
 
 use radix_trie::Trie;
+use qp_trie::Trie as QpTrie;
+use qp_trie::wrapper::BString;
 
 #[cfg(test)]
 fn get_text() -> Vec<String> {
@@ -19,6 +21,17 @@ fn make_trie(words: &[String]) -> Trie<&str, usize> {
 
     for w in words {
         trie.insert(&w[..], w.len());
+    }
+
+    trie
+}
+
+#[cfg(test)]
+fn make_qp_trie(words: &[String]) -> QpTrie<BString, usize> {
+    let mut trie = QpTrie::new();
+
+    for w in words {
+        trie.insert_str(w, w.len());
     }
 
     trie
@@ -67,6 +80,38 @@ fn trie_insert_remove(b: &mut Bencher) {
 
         for w in &words {
             trie.remove(&&w[..]);
+        }
+    });
+}
+
+#[bench]
+fn qp_trie_insert(b: &mut Bencher) {
+    let words = get_text();
+
+    b.iter(|| {
+        make_qp_trie(&words);
+    });
+}
+
+#[bench]
+fn qp_trie_get(b: &mut Bencher) {
+    let words = get_text();
+    let trie = make_qp_trie(&words);
+
+    b.iter(|| {
+        words.iter().map(|w| trie.get_str(w)).collect::<Vec<Option<&usize>>>();
+    });
+}
+
+#[bench]
+fn qp_trie_insert_remove(b: &mut Bencher) {
+    let words = get_text();
+
+    b.iter(|| {
+        let mut trie = make_qp_trie(&words);
+
+        for w in &words {
+            trie.remove_str(w);
         }
     });
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 
 extern crate test as std_test;
+extern crate qp_trie;
 extern crate radix_trie;
-extern crate sequence_trie;
 
 #[cfg(test)]
 mod benchmark;


### PR DESCRIPTION
Initial results are promising @sdleffler

```
test benchmark::qp_trie_get           ... bench:  12,460,459 ns/iter (+/- 1,666,400)
test benchmark::qp_trie_insert        ... bench:  20,203,939 ns/iter (+/- 1,333,453)
test benchmark::qp_trie_insert_remove ... bench:  30,990,026 ns/iter (+/- 2,243,193)
test benchmark::trie_get              ... bench:  27,230,469 ns/iter (+/- 2,636,081)
test benchmark::trie_insert           ... bench:  35,029,133 ns/iter (+/- 2,383,265)
test benchmark::trie_insert_remove    ... bench:  70,183,459 ns/iter (+/- 3,476,240)
```

It looks like `qp-trie` is about twice as fast as `radix_trie`!

If you want to run the benchmark yourself you'll have to set `TEST_FILE=../data/1984.txt`.